### PR TITLE
Disable LTO for android only

### DIFF
--- a/pdfium.lua
+++ b/pdfium.lua
@@ -8,7 +8,7 @@ uuid "5149C8A4-ADEA-47BD-BD79-BA7A8C5B0A89"
 
 flags { "NoPCH" }
 
-if not _PLATFORM_WINDOWS then
+if _PLATFORM_ANDROID then
   buildoptions {
     "-fno-lto"
   }

--- a/pdfium.lua
+++ b/pdfium.lua
@@ -8,6 +8,15 @@ uuid "5149C8A4-ADEA-47BD-BD79-BA7A8C5B0A89"
 
 flags { "NoPCH" }
 
+if not _PLATFORM_WINDOWS then
+  buildoptions {
+    "-fno-lto"
+  }
+  linkoptions {
+    "-fno-lto"
+  }
+end
+
 includedirs {
   ".",
   _3RDPARTY_DIR,


### PR DESCRIPTION
When trying to track down a crash that happens only on android release builds in Pdfium, we disabled LTO so that debug symbols could be generated. However the crash no longer happens with LTO disabled. 

While we continue to look into the crash that happens on android release, we are putting in this change for android only to disable LTO so that we can continue to test other areas of geopdf on android. 

