### PR TITLE
Re-enable LTO for android

### DIFF
--- a/pdfium.lua
+++ b/pdfium.lua
@@ -8,15 +8,6 @@ uuid "5149C8A4-ADEA-47BD-BD79-BA7A8C5B0A89"
 
 flags { "NoPCH" }
 
-if _PLATFORM_ANDROID then
-  buildoptions {
-    "-fno-lto"
-  }
-  linkoptions {
-    "-fno-lto"
-  }
-end
-
 includedirs {
   ".",
   _3RDPARTY_DIR,


### PR DESCRIPTION
Android was previously crashing with LTO enabled. This was due to function merging around a deleter in zlib-ng. Once we upgrade zlib-ng to the latest version, we can re-enable LTO for android: https://github.com/Esri/zlib-ng/pull/3.

