### PR TITLE
Use -O3 optimizations for mobile platforms

### DIFF
--- a/pdfium.lua
+++ b/pdfium.lua
@@ -347,6 +347,10 @@ if not (_PLATFORM_WINDOWS) then
 end
 
 if (_PLATFORM_ANDROID) then
+  buildoptions {
+    "-O3",
+  }
+
   files {
     "core/fxge/android/cfpf_skiadevicemodule.cpp",
     "core/fxge/android/cfpf_skiafont.cpp",
@@ -358,6 +362,10 @@ if (_PLATFORM_ANDROID) then
 end
 
 if (_PLATFORM_IOS) then
+  buildoptions {
+    "-O3",
+  }
+
   files {
     "core/fxge/apple/fx_apple_impl.cpp",
     "core/fxge/apple/fx_apple_platform.cpp",


### PR DESCRIPTION
This PR is to use O3 optimizations for mobile devices as we noticed ~10% performance increase from doing so. 