### PR TITLE
rtc: Adjust span for Android builds

### DIFF
--- a/core/fxcrt/span.h
+++ b/core/fxcrt/span.h
@@ -791,7 +791,11 @@ class GSL_POINTER span {
   template <typename OtherElementType,
             size_t OtherExtent,
             typename OtherInternalPtrType>
+#ifdef RTC_LINUX_ANDROID
+    requires((OtherExtent == dynamic_extent || Extent == OtherExtent) &&
+#else
     requires((OtherExtent == dynamic_extent || extent == OtherExtent) &&
+#endif
              std::equality_comparable_with<const element_type,
                                            const OtherElementType>)
   friend constexpr bool operator==(
@@ -826,7 +830,11 @@ class GSL_POINTER span {
   template <typename OtherElementType,
             size_t OtherExtent,
             typename OtherInternalPtrType>
+#ifdef RTC_LINUX_ANDROID
+    requires((OtherExtent == dynamic_extent || Extent == OtherExtent) &&
+#else
     requires((OtherExtent == dynamic_extent || extent == OtherExtent) &&
+#endif
              std::three_way_comparable_with<const element_type,
                                             const OtherElementType>)
   friend constexpr auto operator<=>(

--- a/pdfium.lua
+++ b/pdfium.lua
@@ -341,10 +341,6 @@ if not (_PLATFORM_WINDOWS) then
 end
 
 if (_PLATFORM_ANDROID) then
-  buildoptions {
-    "-O3",
-  }
-
   files {
     "core/fxge/android/cfpf_skiadevicemodule.cpp",
     "core/fxge/android/cfpf_skiafont.cpp",
@@ -353,17 +349,25 @@ if (_PLATFORM_ANDROID) then
     "core/fxge/android/cfx_androidfontinfo.cpp",
     "core/fxge/android/fx_android_impl.cpp",
   }
-end
 
-if (_PLATFORM_IOS) then
+  configuration { "*release" }
+
   buildoptions {
     "-O3",
   }
+end
 
+if (_PLATFORM_IOS) then
   files {
     "core/fxge/apple/fx_apple_impl.cpp",
     "core/fxge/apple/fx_apple_platform.cpp",
     "core/fxge/apple/fx_quartz_device.cpp",
+  }
+
+  configuration { "*release" }
+
+  buildoptions {
+    "-O3",
   }
 end
 


### PR DESCRIPTION
Use template parameter for concept constraint check instead of the constant 'extent' class member.

Android clang will get upset if the 'span' member constant 'extent' is used in a concept requires statement with the following error:
```
error: no member 'extent' in 'span<const unsigned char>'; it has not yet been instantiated
```
This error does not happen when building pdfium for macOS/Linux/Windows desktop builds. Looking at other implementations of 'span', none of them use the member constant in their concept requires statemets, they only use the template parameter '_Extent'.

Also refactored premake to only apply optimizations to release builds and not both debug and release builds.